### PR TITLE
fix letterbox example

### DIFF
--- a/examples/core/core_window_letterbox.nim
+++ b/examples/core/core_window_letterbox.nim
@@ -39,8 +39,8 @@ setTextureFilter(target.texture, Bilinear)
 ##  Texture scale filter to use
 var colors: array[10, Color]
 for color in colors.mitems:
-  color = Color(r: getRandomValue(100, 250).uint8, g: getRandomValue(100, 250).uint8,
-                b: getRandomValue(100, 250).uint8, a: 255'u8)
+  color = Color(r: getRandomValue(100, 250).uint8, g: getRandomValue(50, 150).uint8,
+                b: getRandomValue(10, 100).uint8, a: 255'u8)
 setTargetFPS(60)
 ##  Set our game to run at 60 frames-per-second
 ## --------------------------------------------------------------------------------------
@@ -54,19 +54,19 @@ while not windowShouldClose(): ##  Detect window close button or ESC key
   if isKeyPressed(Space):
     ##  Recalculate random colors for the bars
     for color in colors.mitems:
-      color = Color(r: getRandomValue(100, 250).uint8, g: getRandomValue(100, 250).uint8,
-                    b: getRandomValue(100, 250).uint8, a: 255'u8)
+      color = Color(r: getRandomValue(100, 250).uint8, g: getRandomValue(50, 150).uint8,
+                    b: getRandomValue(10, 100).uint8, a: 255'u8)
   var mouse: Vector2 = getMousePosition()
   var virtualMouse: Vector2
   virtualMouse.x = (mouse.x - (getScreenWidth() - (gameScreenWidth * scale)) * 0.5) / scale
   virtualMouse.y = (mouse.y - (getScreenHeight() - (gameScreenHeight * scale)) * 0.5) / scale
   virtualMouse = clampValue(virtualMouse, (0.0, 0.0), (gameScreenWidth.float, gameScreenHeight.float))
   ##  Apply the same transformation as the virtual mouse to the real mouse (i.e. to work with raygui)
-  setMouseOffset(
-    -(getScreenWidth() - (gameScreenWidth * scale)*0.5).cint,
-    -(getScreenHeight() - (gameScreenHeight * scale)*0.5).cint
-  )
-  setMouseScale(1.0/scale, 1.0/scale)
+  # setMouseOffset(
+  #   -((getScreenWidth() - (gameScreenWidth * scale)) * 0.5).cint,
+  #   -((getScreenHeight() - (gameScreenHeight * scale)) * 0.5).cint
+  # )
+  # setMouseScale(1.0/scale, 1.0/scale)
 
   ## ----------------------------------------------------------------------------------
   ##  Draw


### PR DESCRIPTION
Fix core_window_letterbox.nim to more closely mirror the original
(https://github.com/raysan5/raylib/blob/master/examples/core/core_window_letterbox.c)

* fix math bug in setMouseOffset due to wrong parentheses (compare to the `virtualMouse.x = ...` line to confirm that there is a bug here -- the two locations perform the math differently from each other. or just launch the example - the text displays have nonsensical outputs)
* comment out setMouseOffset/setMouseScale to match original and avoid confusing output (when I ran it for the first time, these lines made the output display very confusing to me)
* change ranges to sample colors from (minor)