### PR TITLE
fixes #50 ; undefine near and far macros (from windows.h) in the generated headers

### DIFF
--- a/src/prepare_build_files.nim
+++ b/src/prepare_build_files.nim
@@ -71,6 +71,10 @@ when defined(nimraylib_now_mangle):
       raylibBuildDir/"raudio.c",
       raylibBuildDir/"rcore.c",
     ]
+    headerPreamble = [
+      "#undef near", # undefine clashing macros (from windows.h)
+      "#undef far", # undefine clashing macros (from windows.h)
+    ].join("\n") & "\n"
 
   func mangle(line: string): string =
     result = line
@@ -79,7 +83,8 @@ when defined(nimraylib_now_mangle):
 
   # Modify raylib files in-place inside build/ directory
   for file in raylibHeaders:
-    let fileContent = readFile(file)
+    var fileContent: string = headerPreamble
+    fileContent.add readFile(file)
     writeFile(file, mangle(fileContent))
   for file in raylibSources:
     let fileContent = readFile(file)


### PR DESCRIPTION
fixes #50 
pr #51 not needed

Signed-off-by: David Krause <enthus1ast@users.noreply.github.com>