### PR TITLE
Updated README.md to include a better fix for the windows problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ basic nim applications. It does not however have libwinpthread-1.dll, which caus
 We can solve this by instructing nim to create binaries with the libraries 
 linked statically.
 
-To do this just pass in the `-passL:-static` to nim when compiling your file.
+To do this just pass in the `--passL:-static` to nim when compiling your file.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -377,13 +377,15 @@ choosing X11 version of glfw.
 
 ### Windows error: The application was unable to start correctly (0x00000007b)
 Or similar errors which point to missing `libwinpthread-1.dll` file mean that
-you do not have path set correctly and MinGW can't find correct library files.
+windows can't find correct library files.
 
-Based on [this answer in stack-overflow](https://stackoverflow.com/a/71207932) you can do the following to fix the problem:
-- Install [MSYS2](https://www.msys2.org/) x64
-- Open MSYS2 MinGW x64 command prompt
-- Run `pacman -S base-devel mingw-w64-x86_64-toolchain` to install the GCC toolchain (all components)
-- Add `c:\msys64\mingw64\bin` to the System PATH
+This is because, by default, nim creates binaries that are dynamically linked.
+Normally, this is fine since windows already has the libraries required for most
+basic nim applications. It does not however have libwinpthread-1.dll, which causes an error here.
+We can solve this by instructing nim to create binaries with the libraries 
+linked statically.
+
+To do this just pass in the `-passL:-static` to nim when compiling your file.
 
 ## Community
 


### PR DESCRIPTION
Changed the Troubleshooting section of README.md to include an easier and more sensible fix for the windows problem. 
Nim (1.6.6) at least already ships with libwinpthread-1.dll in mingw. The windows problem arises because libwinpthread-1.dll is not on PATH.  Using static libraries means that we no longer need libwinpthread-1.dll to be on PATH.

This is a solution is faster and easier than the previously recommended solution of installing the entire gcc toolchain (which is unnecessary given nim already has the toolchain installed in a default windows install).