### PR TITLE
Added cstring() to avoid implicit conversion to 'cstring' from a non-const location

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,10 +202,10 @@ while not windowShouldClose():
         let
           text = "I AM NIM"
           fontSize = 60
-          textWidth = measureText(text, fontSize)
+          textWidth = measureText(cstring(text), fontSize)
           verticalPos = (getScreenHeight().float * 0.4).int
         drawText(
-          text,
+          cstring(text),
           (getScreenWidth() - textWidth) div 2,  # center
           (getScreenHeight() + verticalPos) div 2,
           fontSize,
@@ -215,7 +215,7 @@ while not windowShouldClose():
         let text =
           if pause: "Press Space to continue"
           else: "Press Space to pause"
-        drawText(text, 10, 10, 20, Black)
+        drawText(cstring(text), 10, 10, 20, Black)
 
 closeWindow()
 ```

--- a/examples/original/crown.nim
+++ b/examples/original/crown.nim
@@ -104,10 +104,10 @@ while not windowShouldClose():
         let
           text = "I AM NIM"
           fontSize = 60
-          textWidth = measureText(text, fontSize)
+          textWidth = measureText(cstring(text), fontSize)
           verticalPos = (getScreenHeight().float * 0.4).int
         drawText(
-          text,
+          cstring(text),
           (getScreenWidth() - textWidth) div 2,  # center
           (getScreenHeight() + verticalPos) div 2,
           fontSize,
@@ -117,6 +117,6 @@ while not windowShouldClose():
         let text =
           if pause: "Press Space to continue"
           else: "Press Space to pause"
-        drawText(text, 10, 10, 20, Black)
+        drawText(cstring(text), 10, 10, 20, Black)
 
 closeWindow()


### PR DESCRIPTION
Great wrapper by the way, it's been very easy to use.
In the `README.md`, there is a `crown.nim` example. It showcases the project very nicely, however when you compile it with `nim 1.6.8` with the recommended compiler settings in the project, it gives out the compiler warning 
```implicit conversion to 'cstring' from a non-const location```
 and that it will be an compiler error in the future.

The solution is to simply use `cstring(text)`, and by adding it 3 times, it compiles without any warnings or prophecies of incoming doom.

I changed both `README.md` and `crown.nim` to reflect these changes
